### PR TITLE
feat: adicionar regra para verificar arquivo CONTRIBUTING.md

### DIFF
--- a/rules/my_registry.go
+++ b/rules/my_registry.go
@@ -14,4 +14,5 @@ func init() {
 	MyRegistry.AddRule(NewWithoutGitlabCI())
 	MyRegistry.AddRule(NewWithoutReadme())
 	MyRegistry.AddRule(NewWithoutMakefile())
+	MyRegistry.AddRule(&WithoutContributing{})
 }

--- a/rules/without_contributing.go
+++ b/rules/without_contributing.go
@@ -1,0 +1,26 @@
+package rules
+
+// WithoutContributing checks if the project has a CONTRIBUTING.md file
+type WithoutContributing struct{}
+
+// Run executes the rule check
+func (r WithoutContributing) Run(p Project) RuleResult {
+	if p.ContributingFile == "" {
+		return RuleResult{
+			Failed:  true,
+			Message: "Project does not have a CONTRIBUTING.md file",
+		}
+	}
+
+	return RuleResult{Failed: false}
+}
+
+// GetLevel returns the rule level
+func (r WithoutContributing) GetLevel() string {
+	return Warning
+}
+
+// GetTitle returns the rule title
+func (r WithoutContributing) GetTitle() string {
+	return "Without Contributing Guide"
+}

--- a/rules/without_contributing.go
+++ b/rules/without_contributing.go
@@ -1,26 +1,26 @@
 package rules
 
-// WithoutContributing checks if the project has a CONTRIBUTING.md file
+// WithoutContributing verifica se o projeto possui um arquivo CONTRIBUTING.md
 type WithoutContributing struct{}
 
-// Run executes the rule check
+// Run executa a verificação da regra
 func (r WithoutContributing) Run(p Project) RuleResult {
-	if p.ContributingFile == "" {
+	if p.ContributingURL == "" {
 		return RuleResult{
 			Failed:  true,
-			Message: "Project does not have a CONTRIBUTING.md file",
+			Message: "Projeto não possui arquivo CONTRIBUTING.md",
 		}
 	}
 
 	return RuleResult{Failed: false}
 }
 
-// GetLevel returns the rule level
+// GetLevel retorna o nível da regra
 func (r WithoutContributing) GetLevel() string {
 	return Warning
 }
 
-// GetTitle returns the rule title
+// GetTitle retorna o título da regra
 func (r WithoutContributing) GetTitle() string {
-	return "Without Contributing Guide"
+	return "Sem Guia de Contribuição"
 }

--- a/rules/without_contributing_test.go
+++ b/rules/without_contributing_test.go
@@ -1,0 +1,29 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithoutContributing(t *testing.T) {
+	rule := WithoutContributing{}
+
+	t.Run("when project has CONTRIBUTING.md", func(t *testing.T) {
+		project := mockProject()
+		project.ContributingFile = "# Contributing Guide"
+		
+		result := rule.Run(project)
+		assert.False(t, result.Failed)
+		assert.Empty(t, result.Message)
+	})
+
+	t.Run("when project does not have CONTRIBUTING.md", func(t *testing.T) {
+		project := mockProject()
+		project.ContributingFile = ""
+		
+		result := rule.Run(project)
+		assert.True(t, result.Failed)
+		assert.Equal(t, "Project does not have a CONTRIBUTING.md file", result.Message)
+	})
+}

--- a/rules/without_contributing_test.go
+++ b/rules/without_contributing_test.go
@@ -9,21 +9,21 @@ import (
 func TestWithoutContributing(t *testing.T) {
 	rule := WithoutContributing{}
 
-	t.Run("when project has CONTRIBUTING.md", func(t *testing.T) {
+	t.Run("quando o projeto tem arquivo CONTRIBUTING.md", func(t *testing.T) {
 		project := mockProject()
-		project.ContributingFile = "# Contributing Guide"
+		project.ContributingURL = "https://gitlab.com/example/project/-/blob/master/CONTRIBUTING.md"
 		
 		result := rule.Run(project)
 		assert.False(t, result.Failed)
 		assert.Empty(t, result.Message)
 	})
 
-	t.Run("when project does not have CONTRIBUTING.md", func(t *testing.T) {
+	t.Run("quando o projeto não tem arquivo CONTRIBUTING.md", func(t *testing.T) {
 		project := mockProject()
-		project.ContributingFile = ""
+		project.ContributingURL = ""
 		
 		result := rule.Run(project)
 		assert.True(t, result.Failed)
-		assert.Equal(t, "Project does not have a CONTRIBUTING.md file", result.Message)
+		assert.Equal(t, "Projeto não possui arquivo CONTRIBUTING.md", result.Message)
 	})
 }


### PR DESCRIPTION
Adiciona uma nova regra que verifica se o projeto possui um arquivo CONTRIBUTING.md.

Alterações realizadas:
- Implementa verificação do arquivo CONTRIBUTING.md usando ContributingURL
- Adiciona testes para validar o comportamento da regra
- Traduz mensagens e documentação para português
- Configura a regra como nível WARNING para incentivar boas práticas

Ter um guia de contribuição é uma boa prática em projetos de código aberto, pois ajuda novos contribuidores a entender como podem colaborar com o projeto.